### PR TITLE
Simple fix so that X-Request-ID is passed through if present

### DIFF
--- a/flask_request_id/middleware.py
+++ b/flask_request_id/middleware.py
@@ -11,7 +11,7 @@ class RequestID(object):
         Adds the Request ID middleware to your current app
         :param app: Flask APP
         :param header_name: The header name returned, X-Request-ID by default
-        :type header_name: string 
+        :type header_name: string
         :param generator_func: Generator function, returning a string. By default, will generate an uuid v4
         :type generator_func: func
         """
@@ -24,8 +24,9 @@ class RequestID(object):
         app.wsgi_app = self
 
     def __call__(self, environ, start_response):
-        req_id = self._generator_func()
-        environ["HTTP_{0}".format(self._flask_header_name)] = req_id
+        header_key = "HTTP_{0}".format(self._flask_header_name)
+        environ.setdefault(header_key, self._generator_func())
+        req_id = environ[header_key]
         environ["FLASK_REQUEST_ID"] = req_id
 
         def new_start_response(status, response_headers, exc_info=None):

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -45,3 +45,12 @@ def test_req_id_custom_generator(app, client):
     assert r.status_code == 200
     assert r.headers['App-Request-ID'] == "test-request-id"
     assert r.data.decode("utf-8") == "test-request-id"
+
+
+def test_req_id_passthrough(app, client):
+    RequestID(app)
+    request_id = "test-request-id2"
+    r = client.get("/", headers={'X-Request-ID': request_id})
+    assert r.status_code == 200
+    assert r.headers['X-Request-ID'] == request_id
+    assert r.data.decode("utf-8") == request_id


### PR DESCRIPTION
Hi geoffreybauduin, here is a simple fix that will make sure X-Request-ID header is passed through if present (rather than always regenerated).

If the X-Request-ID request header is not present, then a new one is generated, otherwise the original one is preserved. This is helpful for tracking requests between individual services, the first service generates a new request ID and all the subsequent services just pass it through.